### PR TITLE
feat: add scroll-to-top button for better navigation

### DIFF
--- a/UniFlux/Client/src/App.tsx
+++ b/UniFlux/Client/src/App.tsx
@@ -28,6 +28,7 @@ import ReportsManagement from './components/Reports/ReportsManagement';
 import SettingsManagement from './components/Settings/SettingsManagement';
 import AcademicCalendarPage from './components/AcademicCalendar/AcademicCalendarPage';
 import UserFeedback from './components/Feedback/UserFeedback';
+import ScrollToTop from "./components/ScrollToTop"
 
 // Footer Pages
 import PrivacyPolicy from './components/Footer/PrivacyPolicy';
@@ -78,6 +79,7 @@ function App() {
         {/* Redirect from root to role selection */}
         <Route path="/" element={<RoleSelection />} />
       </Routes>
+      <ScrollToTop />
     </Router>
   );
 }

--- a/UniFlux/Client/src/components/ScrollToTop.tsx
+++ b/UniFlux/Client/src/components/ScrollToTop.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react"
+import { ArrowUp } from "lucide-react"
+
+export default function ScrollToTop() {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const toggleVisibility = () => {
+      setVisible(window.scrollY > 300)
+    }
+
+    window.addEventListener("scroll", toggleVisibility)
+    return () => window.removeEventListener("scroll", toggleVisibility)
+  }, [])
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: "smooth" })
+  }
+
+  if (!visible) return null
+
+  return (
+    <button
+  onClick={scrollToTop}
+  className="
+    fixed bottom-6 right-6 z-50
+    rounded-full bg-blue-600 p-3 text-black
+    shadow-lg transition-all duration-300 ease-out
+    hover:-translate-y-1 hover:scale-110
+    hover:bg-black hover:text-blue-600
+    hover:shadow-cyan-400/50 hover:shadow-2xl
+  "
+  aria-label="Scroll to top"
+>
+  <ArrowUp size={20} />
+</button>
+  )
+}
+


### PR DESCRIPTION
## 🚀 Feature: Scroll to Top Button

### What this PR does
- Adds a **Scroll-to-Top button** to improve user navigation on long pages
- Allows users to quickly return to the top with a single click

Fixes #59 

### Video

https://github.com/user-attachments/assets/c3b0f082-9bfc-4407-947c-5609e96a2da6


### Why this is needed
- Long dashboards and pages require excessive scrolling
- Improves overall user experience and accessibility
- Common UX pattern used in modern web applications

### Implementation details
- Button appears only after scrolling down
- Smooth scroll behavior for better UX
- Lightweight and non-intrusive
- Frontend-only change

### Scope of changes
- No backend changes
- No breaking changes
- Existing functionality remains unaffected

### Tested
- Scroll-to-top button appears after scrolling
- Clicking the button scrolls smoothly to the top
- App works as expected across dashboard pages
